### PR TITLE
Update to NuGet 5.5.1

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -40,9 +40,9 @@ stages:
             submodules: true
     
           - task: NuGetToolInstaller@0
-            displayName: 'Use NuGet 4.4.1'
+            displayName: 'Use NuGet 5.5.1'
             inputs:
-              versionSpec: 4.4.1
+              versionSpec: 5.5.1
 
           - task: NuGetCommand@2
             displayName: 'NuGet restore'


### PR DESCRIPTION
Fixes the issues in ADO Build agent that causes an error of Could not load file or assembly ‘Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a’ or one of its dependencies